### PR TITLE
Fix Firefox accessibility alerts

### DIFF
--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -580,6 +580,11 @@ header .cta {
   appearance: none;  
 }
 
+.language-switcher select::-ms-expand,
+.year-switcher select::-ms-expand {
+  display: none;
+}
+
 .language-switcher option,
 .year-switcher option {
   color: #1A2B49;

--- a/src/templates/base/2019/base.html
+++ b/src/templates/base/2019/base.html
@@ -141,8 +141,9 @@
             <li class="misc">
               <ul class="misc">
                 <li>
-                  <a href="https://httparchive.org/" class="navigation-logo" aria-label="{{ self.http_archive_link() }}">
-                    <svg width="70" height="35">
+                  <a href="https://httparchive.org/" class="navigation-logo" aria-labelledby="ha-logo-mobile">
+                    <svg width="70" height="35" role="img">
+                      <title id="ha-logo-mobile">{{ self.http_archive_link() }}</title>
                       <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ha"></use>
                     </svg>
                   </a>
@@ -150,15 +151,17 @@
                 <li>
                   <ul class="social-media">
                     <li>
-                      <a href="https://twitter.com/HTTPArchive" aria-label="Twitter">
-                        <svg width="20" height="20">
+                      <a href="https://twitter.com/HTTPArchive" aria-labelledby="twitter-logo-mobile">
+                        <svg width="20" height="20" role="img">
+                          <title id="twitter-logo-mobile">Twitter</title>
                           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#twitter"></use>
                         </svg>
                       </a>
                     </li>
                     <li>
-                      <a href="https://github.com/HTTPArchive/almanac.httparchive.org" aria-label="GitHub">
-                        <svg width="20" height="20">
+                      <a href="https://github.com/HTTPArchive/almanac.httparchive.org" aria-labelledby="github-logo-mobile">
+                        <svg width="20" height="20" role="img">
+                          <title id="github-logo-mobile">GitHub</title>
                           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#github"></use>
                         </svg>
                       </a>
@@ -198,22 +201,25 @@
         </ul>
       </nav>
       <div class="mobile-ha-social-media">
-        <a class="navigation-logo ha-logo" href="https://httparchive.org/" aria-label="{{ self.http_archive_link() }}">
-          <svg width="70" height="35">
+        <a class="navigation-logo ha-logo" href="https://httparchive.org/" aria-labelledby="httparchive-logo-footer-mobile">
+          <svg width="70" height="35" role="img">
+            <title id="httparchive-logo-footer-mobile">{{ self.http_archive_link() }}</title>
             <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ha"></use>
           </svg>
         </a>
         <ul class="social-media">
           <li>
-            <a href="https://twitter.com/HTTPArchive" aria-label="Twitter">
-              <svg width="20" height="20">
+            <a href="https://twitter.com/HTTPArchive" aria-labelledby="twitter-logo-footer-mobile">
+              <svg width="20" height="20" role="img">
+                <title id="twitter-logo-footer-mobile">Twitter</title>
                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#twitter"></use>
               </svg>
             </a>
           </li>
           <li>
-            <a href="https://github.com/HTTPArchive/almanac.httparchive.org" aria-label="GitHub">
-              <svg width="20" height="20">
+            <a href="https://github.com/HTTPArchive/almanac.httparchive.org" aria-labelledby="github-logo-footer-mobile">
+              <svg width="20" height="20" role="img">
+                <title id="github-logo-footer-mobile">GitHub</title>
                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#github"></use>
               </svg>
             </a>
@@ -226,22 +232,25 @@
         <br>
         <a href="{{ url_for('accessibility_statement', lang=lang) }}">{{ self.accessibility_statement() }}</a>
       </p>
-      <a class="navigation-logo ha-logo not-mobile" href="https://httparchive.org/" aria-label="{{ self.http_archive_link() }}">
-        <svg width="70" height="35">
+      <a class="navigation-logo ha-logo not-mobile" href="https://httparchive.org/" aria-labelledby="ha-logo-footer">
+        <svg width="70" height="35" role="img">
+          <title id="ha-logo-footer">{{ self.http_archive_link() }}</title>
           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ha"></use>
         </svg>        
       </a>
       <ul class="social-media not-mobile">
         <li>
-          <a href="https://twitter.com/HTTPArchive" aria-label="Twitter">
-            <svg width="20" height="20">
+          <a href="https://twitter.com/HTTPArchive" aria-labelledby="twitter-logo-footer">
+            <svg width="20" height="20" role="img">
+              <title id="twitter-logo-footer">Twitter</title>
               <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#twitter"></use>
             </svg>
           </a>
         </li>
         <li>
-          <a href="https://github.com/HTTPArchive/almanac.httparchive.org" aria-label="GitHub">
-            <svg width="20" height="20">
+          <a href="https://github.com/HTTPArchive/almanac.httparchive.org" aria-labelledby="github-logo-footer">
+            <svg width="20" height="20" role="img">
+              <title id="github-logo-footer">GitHub</title>
               <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#github"></use>
             </svg>
           </a>

--- a/src/templates/base/2019/base_chapter.html
+++ b/src/templates/base/2019/base_chapter.html
@@ -61,21 +61,21 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
 {# Calls to action for readers who want to engage more with this chapter. #}
 {% macro render_actions() %}
   <a class="alt btn" href="https://discuss.httparchive.org/t/{{ metadata.get('discuss') }}">
-    <svg width="18" height="18">
-    <title>{{ self.discuss_this_chapter() }}</title>
+    <svg width="18" height="18" role="img">
+      <title>{{ self.discuss_this_chapter() }}</title>
       <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#comment"></use>
     </svg>    
     <span id="num_comments"></span> <span data-translation id="comment-singular">{{ self.comment() }}</span>
     <span data-translation id="comment-plural">{{ self.comments() }}</span>
   </a>
   <a class="alt btn" href="{{ metadata.get('results') }}/">
-    <svg width="18" height="18" aria-hidden="true">
+    <svg width="18" height="18" role="img" aria-hidden="true">
       <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#bar-chart"></use>
     </svg>       
     {{ self.results() }}
   </a>
   <a class="alt btn" href="https://github.com/HTTPArchive/almanac.httparchive.org/tree/master/sql/{{ year }}/{{ metadata.get('queries')  }}/">
-    <svg width="18" height="18" aria-hidden="true">
+    <svg width="18" height="18" role="img" aria-hidden="true">
       <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#sql"></use>
     </svg>   
     {{ self.queries() }}
@@ -132,22 +132,25 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
               {% if authordata.twitter or authordata.github %}
                   <span class="social">
                   {% if authordata.twitter %}
-                  <a class="twitter" href="https://twitter.com/{{ authordata.twitter }}" aria-label="{{ onTwitter(authordata.twitter) }}">
-                    <svg width="18" height="18">
+                  <a class="twitter" href="https://twitter.com/{{ authordata.twitter }}" aria-labelledby="author_{{ authordata.twitter }}">
+                    <svg width="18" height="18" role="img">
+                      <title id="author_{{ authordata.twitter }}">{{ onTwitter(authordata.twitter) }}</title>
                       <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#twitter"></use>
                     </svg>
                   </a>
                   {% endif %}
                   {% if authordata.github %}
-                  <a class="github" href="https://github.com/{{ authordata.github }}" aria-label="{{ onGitHub(authordata.github) }}">
-                    <svg width="18" height="18">
+                  <a class="github" href="https://github.com/{{ authordata.github }}" aria-labelledby="author_{{ authordata.github }}">
+                    <svg width="18" height="18" role="img">
+                      <title id="author_{{ authordata.github }}">{{ onGitHub(authordata.github) }}</title>
                       <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#github"></use>
                     </svg>
                   </a>
                   {% endif %}
                   {% if authordata.website %}
-                  <a class="website" href="{{ authordata.website }}" aria-label="{{ website(authordata.name) }}">
-                    <svg width="18" height="18">
+                  <a class="website" href="{{ authordata.website }}" aria-labelledby="author_{{ author }}_website">
+                    <svg width="18" height="18" role="img">
+                      <title id="author_{{ author }}_website">{{ website(authordata.name) }}</title>
                       <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#globe"></use>
                     </svg>
                   </a>


### PR DESCRIPTION
@catalinred Firefox accessibility audit was still complaining about some things. Played around and read some articles on accessible SVGs, and this seems to fix it. As I had the fixes, though easier to submit a PR than ask you to repeat my work!

Basically:

- Give every SVG `role="img"` attributes
- Give every non-presentational SVG a `<title>` element with a unique id
- Add `aria-labelledby` attributes pointing to above `<title>` elements where appropriate.

Also fixes a small issue with the select menu on IE11. Know we don't officially support IE11 (and it looks pretty poor due to it not supporting grid) but was curious and was an easy fix to including that.